### PR TITLE
Fixed formatting of time strings without seconds

### DIFF
--- a/commonxl/fmt_test.go
+++ b/commonxl/fmt_test.go
@@ -139,3 +139,18 @@ func TestBoolFormats(t *testing.T) {
 		t.Fatal(`-99.0 should be "yes"`)
 	}
 }
+
+func TestTimeFormats(t *testing.T) {
+	formatter := Formatter{}
+	formatter.Add(165, "hh:mm")
+
+	testTime := time.Date(2014, 3, 27, 9, 37, 0, 0, time.UTC)
+	val, ok := formatter.Apply(165, testTime)
+	if ok != true {
+		t.Fatal("Could not format time")
+	}
+
+	if val != "09:37" {
+		t.Fatal("Time should be 09:37, but was", val)
+	}
+}

--- a/commonxl/formats.go
+++ b/commonxl/formats.go
@@ -64,7 +64,7 @@ func (x *Formatter) getCellType(fmtID uint16) (CellType, bool) {
 }
 
 var (
-	minsMatch = regexp.MustCompile("h.*m.*s")
+	minsMatch = regexp.MustCompile("h.*m.*s*")
 	nonEsc    = regexp.MustCompile(`([^"]|^)"`)
 	squash    = regexp.MustCompile(`[*_].`)
 	fixEsc    = regexp.MustCompile(`\\(.)`)


### PR DESCRIPTION
When creating a formatter with the format "hh:mm", then makeFormatters will not detect the "mm" as minutes, but as months, and will therefore create an incorrect output. For example, the 22nd November at the time 13:37 will produce "13:11" instead of "13:37", as expected.

This commit adds a unit test for the errornous case and a fix for the regular expression that detects a time string. Now, seconds are optional.

It is probably a good idea to rethink the regex, as it might produce more errors.